### PR TITLE
Fix wrong dimensions in RNFA mask

### DIFF
--- a/ocp_tool/scriptengine_task.py
+++ b/ocp_tool/scriptengine_task.py
@@ -220,7 +220,7 @@ else:
             else:
                 ocpt.oasis.write_mask(
                     name=oasis_grid_names['rnfm-atm'],
-                    masks=np.zeros((rnfm_grid.nlons, rnfm_grid.nlats))
+                    masks=np.zeros((rnfm_grid.nlats, rnfm_grid.nlons))
                 )
 
             # AMIP Forcing-reader grid


### PR DESCRIPTION
`RNFA.msk` in `masks.nc` has the dimensions in the wrong order. It should be 512x256, but it is 256x512. Besides being wrong it is also inconsistent with the dimensions of coordinates `RNFA.*` in grids.nc.